### PR TITLE
Enable VTS MostRecent feature in SDK

### DIFF
--- a/Artesian/Artesian.SDK.Tests/VersionedTimeSerieQueries.cs
+++ b/Artesian/Artesian.SDK.Tests/VersionedTimeSerieQueries.cs
@@ -891,11 +891,11 @@ namespace Artesian.SDK.Tests
                 var ver = qs.CreateVersioned()
                         .ForMarketData(new [] { 100000001 })
                         .InGranularity(Granularity.Day)
-                        .ForMostRecent(new LocalDateTime(2018, 5, 21, 12, 0, 0), new LocalDateTime(2018, 7, 23, 0, 0, 0))
+                        .ForMostRecent(new LocalDateTime(2018, 5, 21, 12, 30, 15), new LocalDateTime(2018, 7, 23, 8, 45, 30))
                         .InRelativeInterval(RelativeInterval.MonthToDate)
                         .ExecuteAsync().Result;
 
-                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-05-21T12:00:00/2018-07-23T00:00:00/Day/MonthToDate")
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-05-21T12:30:15/2018-07-23T08:45:30/Day/MonthToDate")
                  .WithQueryParam("id", 100000001)
                  .WithVerb(HttpMethod.Get)
                  .Times(1);

--- a/Artesian/Artesian.SDK.Tests/VersionedTimeSerieQueries.cs
+++ b/Artesian/Artesian.SDK.Tests/VersionedTimeSerieQueries.cs
@@ -706,7 +706,7 @@ namespace Artesian.SDK.Tests
                         .InAbsoluteDateRange(new LocalDate(2018, 6, 22), new LocalDate(2018, 7, 23))
                         .ExecuteAsync().Result;
 
-                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-06-22/2018-07-23/Day/2018-06-22/2018-07-23")
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-06-22T00:00:00/2018-07-23T00:00:00/Day/2018-06-22/2018-07-23")
                  .WithQueryParam("id", 100000001)
                  .WithVerb(HttpMethod.Get)
                  .Times(1);
@@ -727,7 +727,7 @@ namespace Artesian.SDK.Tests
                         .InRelativePeriod(Period.FromDays(5))
                         .ExecuteAsync().Result;
 
-                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-06-22/2018-07-23/Day/P5D")
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-06-22T00:00:00/2018-07-23T00:00:00/Day/P5D")
                  .WithQueryParam("id", 100000001)
                  .WithVerb(HttpMethod.Get)
                  .Times(1);
@@ -744,11 +744,11 @@ namespace Artesian.SDK.Tests
                 var ver = qs.CreateVersioned()
                         .ForMarketData(new [] { 100000001 })
                         .InGranularity(Granularity.Day)
-                        .ForMostRecent(new LocalDate(2018, 6, 22), new LocalDate(2018, 7, 23))
+                        .ForMostRecent(new LocalDateTime(2018, 6, 22, 0, 0, 0), new LocalDateTime(2018, 7, 23, 0, 0, 0))
                         .InRelativePeriodRange(Period.FromWeeks(2), Period.FromDays(20))
                         .ExecuteAsync().Result;
 
-                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-06-22/2018-07-23/Day/P2W/P20D")
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-06-22T00:00:00/2018-07-23T00:00:00/Day/P2W/P20D")
                    .WithQueryParam("id", 100000001)
                    .WithVerb(HttpMethod.Get)
                    .Times(1);
@@ -891,11 +891,11 @@ namespace Artesian.SDK.Tests
                 var ver = qs.CreateVersioned()
                         .ForMarketData(new [] { 100000001 })
                         .InGranularity(Granularity.Day)
-                        .ForMostRecent(new LocalDate(2018, 5, 22), new LocalDate(2018, 7, 23))
+                        .ForMostRecent(new LocalDateTime(2018, 5, 21, 12, 0, 0), new LocalDateTime(2018, 7, 23, 0, 0, 0))
                         .InRelativeInterval(RelativeInterval.MonthToDate)
                         .ExecuteAsync().Result;
 
-                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-05-22/2018-07-23/Day/MonthToDate")
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/2018-05-21T12:00:00/2018-07-23T00:00:00/Day/MonthToDate")
                  .WithQueryParam("id", 100000001)
                  .WithVerb(HttpMethod.Get)
                  .Times(1);

--- a/Artesian/Artesian.SDK/Service/Query/Configuration/MostRecentConfig.cs
+++ b/Artesian/Artesian.SDK/Service/Query/Configuration/MostRecentConfig.cs
@@ -10,11 +10,11 @@ namespace Artesian.SDK.Service
         /// <summary>
         /// Start date for date range
         /// </summary>
-        public LocalDate? DateStart { get; set; }
+        public LocalDateTime? DateStart { get; set; }
         /// <summary>
         /// End date for date range
         /// </summary>
-        public LocalDate? DateEnd { get; set; }
+        public LocalDateTime? DateEnd { get; set; }
         /// <summary>
         /// Period
         /// </summary>

--- a/Artesian/Artesian.SDK/Service/Query/QueryWithRange.cs
+++ b/Artesian/Artesian.SDK/Service/Query/QueryWithRange.cs
@@ -121,6 +121,11 @@ namespace Artesian.SDK.Service
             return $"{_localDatePattern.Format(start)}/{_localDatePattern.Format(end)}";
         }
 
+        internal string _toUrlParam(LocalDateTime start, LocalDateTime end)
+        {
+            return $"{_localDateTimePattern.Format(start)}/{_localDateTimePattern.Format(end)}";
+        }
+
         internal string _toUrlParam(LocalDateTime dateTime)
         {
             return _localDateTimePattern.Format(dateTime);

--- a/Artesian/Artesian.SDK/Service/Query/VersionedQuery.cs
+++ b/Artesian/Artesian.SDK/Service/Query/VersionedQuery.cs
@@ -187,6 +187,23 @@ namespace Artesian.SDK.Service
                 throw new ArgumentException("End date " + end + " must be greater than start date " + start);
 
             _queryParamaters.VersionSelectionType = VersionSelectionType.MostRecent;
+            _queryParamaters.VersionSelectionConfig.MostRecent.DateStart = start.AtMidnight();
+            _queryParamaters.VersionSelectionConfig.MostRecent.DateEnd = end.AtMidnight();
+
+            return this;
+        }
+        /// <summary>
+        /// Set Most Recent date range version selection
+        /// </summary>
+        /// <param name="start"></param>
+        /// <param name="end"></param>
+        /// <returns></returns>
+        public VersionedQuery ForMostRecent(LocalDateTime start, LocalDateTime end)
+        {
+            if (end <= start)
+                throw new ArgumentException("End datetime " + end + " must be greater than start datetime " + start);
+
+            _queryParamaters.VersionSelectionType = VersionSelectionType.MostRecent;
             _queryParamaters.VersionSelectionConfig.MostRecent.DateStart = start;
             _queryParamaters.VersionSelectionConfig.MostRecent.DateEnd = end;
 

--- a/Artesian/Artesian.SDK/Service/Query/VersionedQuery.cs
+++ b/Artesian/Artesian.SDK/Service/Query/VersionedQuery.cs
@@ -183,14 +183,7 @@ namespace Artesian.SDK.Service
         /// <returns></returns>
         public VersionedQuery ForMostRecent(LocalDate start, LocalDate end)
         {
-            if (end <= start)
-                throw new ArgumentException("End date " + end + " must be greater than start date " + start);
-
-            _queryParamaters.VersionSelectionType = VersionSelectionType.MostRecent;
-            _queryParamaters.VersionSelectionConfig.MostRecent.DateStart = start.AtMidnight();
-            _queryParamaters.VersionSelectionConfig.MostRecent.DateEnd = end.AtMidnight();
-
-            return this;
+            return ForMostRecent(start.AtMidnight(), end.AtMidnight());
         }
         /// <summary>
         /// Set Most Recent date range version selection


### PR DESCRIPTION
We need to allow the user to specify more strictly the range of versions enabling the usage of datetime version filters.

An example of the new scenario to be supported is the following: I need to extract the most recent version available at the 11:30 of the provider xxx in order to do some backtest of my process for the forecast of the MGP prices
/v1.0/vts/MostRecent/xxxxxT11:00/xxxxxT12:00/{granularity}/...

Requirement: #6848
Tast: #7328