### PR TITLE
Add feature to continue fill strategy when no value for end of reques…

### DIFF
--- a/Artesian/Artesian.SDK.Tests/ActualTimeSerieQueries.cs
+++ b/Artesian/Artesian.SDK.Tests/ActualTimeSerieQueries.cs
@@ -587,6 +587,31 @@ namespace Artesian.SDK.Tests
                 httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/ts/Day/2018-06-22/2018-07-23")
                  .WithQueryParam("id", 100000001)
                  .WithQueryParam("fillerK", FillerKindType.LatestValidValue)
+                 .WithQueryParam("fillerC", false)
+                 .WithQueryParam("fillerP", "P7D")
+                 .WithVerb(HttpMethod.Get)
+                 .Times(1);
+            }
+        }
+
+        [Test]
+        public void FillerLatestValueActInAbsoluteDateRangeMostRecentContinue()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                var qs = new QueryService(_cfg);
+
+                var act = qs.CreateActual()
+                        .ForMarketData(new [] { 100000001 })
+                        .InGranularity(Granularity.Day)
+                        .InAbsoluteDateRange(new LocalDate(2018, 6, 22), new LocalDate(2018, 7, 23))
+                        .WithFillLatestValue(Period.FromDays(7), true)
+                        .ExecuteAsync().Result;
+
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/ts/Day/2018-06-22/2018-07-23")
+                 .WithQueryParam("id", 100000001)
+                 .WithQueryParam("fillerK", FillerKindType.LatestValidValue)
+                 .WithQueryParam("fillerC", true)
                  .WithQueryParam("fillerP", "P7D")
                  .WithVerb(HttpMethod.Get)
                  .Times(1);

--- a/Artesian/Artesian.SDK.Tests/BidAskQueries.cs
+++ b/Artesian/Artesian.SDK.Tests/BidAskQueries.cs
@@ -484,6 +484,32 @@ namespace Artesian.SDK.Tests
                     .WithQueryParamMultiple("p", new [] { "M+1", "GY+1" })
                     .WithQueryParam("fillerK", FillerKindType.LatestValidValue)
                     .WithQueryParam("fillerP","P7D")
+                    .WithQueryParam("fillerC", false)
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void FillerLatestValidValueBidAskInAbsoluteDateRangeExtractionWindowContinue()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                var qs = new QueryService(_cfg);
+
+                var bask = qs.CreateBidAsk()
+                       .ForMarketData(new [] { 100000001 })
+                       .ForProducts(new [] { "M+1", "GY+1" })
+                       .InAbsoluteDateRange(new LocalDate(2018, 1, 1), new LocalDate(2018, 1, 10))
+                       .WithFillLatestValue(Period.FromDays(7), true)
+                       .ExecuteAsync().Result;
+
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/ba/2018-01-01/2018-01-10")
+                    .WithQueryParam("id", 100000001)
+                    .WithQueryParamMultiple("p", new [] { "M+1", "GY+1" })
+                    .WithQueryParam("fillerK", FillerKindType.LatestValidValue)
+                    .WithQueryParam("fillerC", true)
+                    .WithQueryParam("fillerP","P7D")
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
             }

--- a/Artesian/Artesian.SDK.Tests/MarketAssessmentQueries.cs
+++ b/Artesian/Artesian.SDK.Tests/MarketAssessmentQueries.cs
@@ -484,6 +484,32 @@ namespace Artesian.SDK.Tests
                     .WithQueryParamMultiple("p", new [] { "M+1", "GY+1" })
                     .WithQueryParam("fillerK", FillerKindType.LatestValidValue)
                     .WithQueryParam("fillerP","P7D")
+                    .WithQueryParam("fillerC", false)
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+            }
+        }
+
+        [Test]
+        public void FillerLatestValidValueMasInAbsoluteDateRangeExtractionWindowContinue()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                var qs = new QueryService(_cfg);
+
+                var mas = qs.CreateMarketAssessment()
+                       .ForMarketData(new [] { 100000001 })
+                       .ForProducts(new [] { "M+1", "GY+1" })
+                       .InAbsoluteDateRange(new LocalDate(2018, 1, 1), new LocalDate(2018, 1, 10))
+                       .WithFillLatestValue(Period.FromDays(7), true)
+                       .ExecuteAsync().Result;
+
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/mas/2018-01-01/2018-01-10")
+                    .WithQueryParam("id", 100000001)
+                    .WithQueryParamMultiple("p", new [] { "M+1", "GY+1" })
+                    .WithQueryParam("fillerK", FillerKindType.LatestValidValue)
+                    .WithQueryParam("fillerP","P7D")
+                    .WithQueryParam("fillerC", true)
                     .WithVerb(HttpMethod.Get)
                     .Times(1);
             }

--- a/Artesian/Artesian.SDK.Tests/VersionedTimeSerieQueries.cs
+++ b/Artesian/Artesian.SDK.Tests/VersionedTimeSerieQueries.cs
@@ -2721,6 +2721,32 @@ namespace Artesian.SDK.Tests
                  .WithQueryParam("id", 100000001)
                  .WithQueryParam("fillerK", FillerKindType.LatestValidValue)
                  .WithQueryParam("fillerP","P7D")
+                 .WithQueryParam("fillerC", false)
+                 .WithVerb(HttpMethod.Get)
+                 .Times(1);
+            }
+        }
+
+        [Test]
+        public void FillerLatestValueVerInAbsoluteDateRangeMostRecentContinue()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                var qs = new QueryService(_cfg);
+
+                var ver = qs.CreateVersioned()
+                        .ForMarketData(new [] { 100000001 })
+                        .InGranularity(Granularity.Day)
+                        .ForMostRecent()
+                        .InAbsoluteDateRange(new LocalDate(2018, 6, 22), new LocalDate(2018, 7, 23))
+                        .WithFillLatestValue(Period.FromDays(7), true)
+                        .ExecuteAsync().Result;
+
+                httpTest.ShouldHaveCalledPath($"{_cfg.BaseAddress}query/v1.0/vts/MostRecent/Day/2018-06-22/2018-07-23")
+                 .WithQueryParam("id", 100000001)
+                 .WithQueryParam("fillerK", FillerKindType.LatestValidValue)
+                 .WithQueryParam("fillerP","P7D")
+                 .WithQueryParam("fillerC", true)
                  .WithVerb(HttpMethod.Get)
                  .Times(1);
             }

--- a/Artesian/Artesian.SDK/Service/Query/ActualQuery.cs
+++ b/Artesian/Artesian.SDK/Service/Query/ActualQuery.cs
@@ -158,10 +158,12 @@ namespace Artesian.SDK.Service
         /// Set the Filler Strategy to Custom Value
         /// </summary>
         /// <param name="value"></param>
+        /// <param name="fillerContinue"></param>
         /// <returns>ActualQuery</returns>
-        public ActualQuery WithFillCustomValue(double value)
+        public ActualQuery WithFillCustomValue(double value, bool fillerContinue = false)
         {
             _queryParamaters.FillerKindType = FillerKindType.CustomValue;
+            _queryParamaters.FillerContinue = fillerContinue;
             _queryParamaters.FillerConfig.FillerTimeSeriesDV = value;
 
             return this;
@@ -170,10 +172,12 @@ namespace Artesian.SDK.Service
         /// Set the Filler Strategy to Latest Value
         /// </summary>
         /// <param name="period"></param>
+        /// <param name="fillerContinue"></param>
         /// <returns>ActualQuery</returns>
-        public ActualQuery WithFillLatestValue(Period period)
+        public ActualQuery WithFillLatestValue(Period period, bool fillerContinue = false)
         {
             _queryParamaters.FillerKindType = FillerKindType.LatestValidValue;
+            _queryParamaters.FillerContinue = fillerContinue;
             _queryParamaters.FillerConfig.FillerPeriod = period;
 
             return this;
@@ -215,6 +219,7 @@ namespace Artesian.SDK.Service
                         .SetQueryParam("tz", qp.TimeZone)
                         .SetQueryParam("tr", qp.TransformId)
                         .SetQueryParam("fillerK", qp.FillerKindType)
+                        .SetQueryParam("fillerC", qp.FillerContinue)
                         .SetQueryParam("fillerDV", qp.FillerConfig.FillerTimeSeriesDV)
                         .SetQueryParam("fillerP", qp.FillerConfig.FillerPeriod)
                         .ToString())

--- a/Artesian/Artesian.SDK/Service/Query/BidAskQuery.cs
+++ b/Artesian/Artesian.SDK/Service/Query/BidAskQuery.cs
@@ -149,10 +149,12 @@ namespace Artesian.SDK.Service
         /// Set the Filler Strategy to Latest Value
         /// </summary>
         /// <param name="period"></param>
+        /// <param name="fillerContinue"></param>
         /// <returns>BidAskQuery</returns>
-        public BidAskQuery WithFillLatestValue(Period period)
+        public BidAskQuery WithFillLatestValue(Period period, bool fillerContinue = false)
         {
             _queryParamaters.FillerKindType = FillerKindType.LatestValidValue;
+            _queryParamaters.FillerContinue = fillerContinue;
             _queryParamaters.FillerConfig.FillerPeriod = period;
 
             return this;
@@ -194,7 +196,8 @@ namespace Artesian.SDK.Service
                         .SetQueryParam("filterId", qp.FilterId)
                         .SetQueryParam("p", qp.Products)
                         .SetQueryParam("tz", qp.TimeZone)
-                        .SetQueryParam("fillerK",qp.FillerKindType)
+                        .SetQueryParam("fillerK", qp.FillerKindType)
+                        .SetQueryParam("fillerC", qp.FillerContinue)
                         .SetQueryParam("fillerDVbbp",qp.FillerConfig.FillerBidAskDV.BestBidPrice)
                         .SetQueryParam("fillerDVbap", qp.FillerConfig.FillerBidAskDV.BestAskPrice)
                         .SetQueryParam("fillerDVbbq", qp.FillerConfig.FillerBidAskDV.BestBidQuantity)

--- a/Artesian/Artesian.SDK/Service/Query/IActualQuery.cs
+++ b/Artesian/Artesian.SDK/Service/Query/IActualQuery.cs
@@ -11,6 +11,6 @@ namespace Artesian.SDK.Service
         T InGranularity(Granularity granularity);
         T WithTimeTransform(int tr);
         T WithTimeTransform(SystemTimeTransform tr);
-        T WithFillCustomValue(double value);
+        T WithFillCustomValue(double value, bool fillerContinue);
     }
 }

--- a/Artesian/Artesian.SDK/Service/Query/IQueryWithFill.cs
+++ b/Artesian/Artesian.SDK/Service/Query/IQueryWithFill.cs
@@ -8,7 +8,7 @@ namespace Artesian.SDK.Service
     interface IQueryWithFill<T>: IQuery<T>
     {
         T WithFillNull();
-        T WithFillLatestValue(Period period);
+        T WithFillLatestValue(Period period, bool fillerContinue);
         T WithFillNone();
     }
 }

--- a/Artesian/Artesian.SDK/Service/Query/MasQuery.cs
+++ b/Artesian/Artesian.SDK/Service/Query/MasQuery.cs
@@ -149,10 +149,12 @@ namespace Artesian.SDK.Service
         /// Set the Filler Strategy to Latest Value
         /// </summary>
         /// <param name="period"></param>
+        /// <param name="fillerContinue"></param>
         /// <returns>MasQuery</returns>
-        public MasQuery WithFillLatestValue(Period period)
+        public MasQuery WithFillLatestValue(Period period, bool fillerContinue = false)
         {
             _queryParamaters.FillerKindType = FillerKindType.LatestValidValue;
+            _queryParamaters.FillerContinue = fillerContinue;
             _queryParamaters.FillerConfig.FillerPeriod = period;
 
             return this;
@@ -194,8 +196,9 @@ namespace Artesian.SDK.Service
                         .SetQueryParam("filterId", qp.FilterId)
                         .SetQueryParam("p", qp.Products)
                         .SetQueryParam("tz", qp.TimeZone)
-                        .SetQueryParam("fillerK",qp.FillerKindType)
-                        .SetQueryParam("fillerDVs",qp.FillerConfig.FillerMasDV.Settlement)
+                        .SetQueryParam("fillerK", qp.FillerKindType)
+                        .SetQueryParam("fillerC", qp.FillerContinue)
+                        .SetQueryParam("fillerDVs", qp.FillerConfig.FillerMasDV.Settlement)
                         .SetQueryParam("fillerDVo", qp.FillerConfig.FillerMasDV.Open)
                         .SetQueryParam("fillerDVc", qp.FillerConfig.FillerMasDV.Close)
                         .SetQueryParam("fillerDVh", qp.FillerConfig.FillerMasDV.High)

--- a/Artesian/Artesian.SDK/Service/Query/Partitioning/PartitionByIDStrategy.cs
+++ b/Artesian/Artesian.SDK/Service/Query/Partitioning/PartitionByIDStrategy.cs
@@ -34,6 +34,7 @@ namespace Artesian.SDK.Service
                                 queryParamater.Granularity,
                                 queryParamater.TransformId,
                                 queryParamater.FillerKindType,
+                                queryParamater.FillerContinue,
                                 queryParamater.FillerConfig
                                 )));
         }
@@ -62,6 +63,7 @@ namespace Artesian.SDK.Service
                                 queryParamater.VersionSelectionType,
                                 queryParamater.VersionLimit,
                                 queryParamater.FillerKindType,
+                                queryParamater.FillerContinue,
                                 queryParamater.FillerConfig
                                 )));
         }
@@ -86,6 +88,7 @@ namespace Artesian.SDK.Service
                                 queryParamater.FilterId,
                                 queryParamater.Products,
                                 queryParamater.FillerKindType,
+                                queryParamater.FillerContinue,
                                 queryParamater.FillerConfig
                                 )));
         }
@@ -130,6 +133,7 @@ namespace Artesian.SDK.Service
                                 queryParamater.FilterId,
                                 queryParamater.Products,
                                 queryParamater.FillerKindType,
+                                queryParamater.FillerContinue,
                                 queryParamater.FillerConfig
                                 )));
         }

--- a/Artesian/Artesian.SDK/Service/Query/QueryParamaters/ActualQueryParamaters.cs
+++ b/Artesian/Artesian.SDK/Service/Query/QueryParamaters/ActualQueryParamaters.cs
@@ -31,6 +31,7 @@ namespace Artesian.SDK.Service
         /// <param name="timezone"></param>
         /// <param name="filterId"></param>
         /// <param name="fillerK"></param>
+        /// <param name="fillerC"></param>
         /// <param name="fillerConfig"></param>
         public ActualQueryParamaters(
             IEnumerable<int> ids, 
@@ -41,9 +42,10 @@ namespace Artesian.SDK.Service
             Granularity? granularity, 
             int? transformId,
             FillerKindType fillerK,
+            bool fillerC,
             FillerConfig fillerConfig
             )
-            : base(ids,extractionRangeSelectionConfig, extractionRangeType, timezone, filterId, fillerK, fillerConfig)
+            : base(ids,extractionRangeSelectionConfig, extractionRangeType, timezone, filterId, fillerK, fillerC, fillerConfig)
         {           
             this.Granularity = granularity;
             this.TransformId = transformId;

--- a/Artesian/Artesian.SDK/Service/Query/QueryParamaters/BidAskQueryParamaters.cs
+++ b/Artesian/Artesian.SDK/Service/Query/QueryParamaters/BidAskQueryParamaters.cs
@@ -30,6 +30,7 @@ namespace Artesian.SDK.Service
         /// <param name="filterId"></param>
         /// <param name="products"></param>
         /// <param name="fillerK"></param>
+        /// <param name="fillerC"></param>
         /// <param name="fillerConfig"></param>
         public BidAskQueryParamaters(
             IEnumerable<int> ids , 
@@ -39,9 +40,10 @@ namespace Artesian.SDK.Service
             int? filterId,
             IEnumerable<string> products,
             FillerKindType fillerK,
+            bool fillerC,
             FillerConfig fillerConfig
             )
-            : base(ids, extractionRangeSelectionConfig, extractionRangeType, timezone, filterId, fillerK, fillerConfig)
+            : base(ids, extractionRangeSelectionConfig, extractionRangeType, timezone, filterId, fillerK, fillerC, fillerConfig)
         {
             this.Products = products;
             this.FillerConfig = fillerConfig;

--- a/Artesian/Artesian.SDK/Service/Query/QueryParamaters/MasQueryParamaters.cs
+++ b/Artesian/Artesian.SDK/Service/Query/QueryParamaters/MasQueryParamaters.cs
@@ -30,6 +30,7 @@ namespace Artesian.SDK.Service
         /// <param name="filterId"></param>
         /// <param name="products"></param>
         /// <param name="fillerK"></param>
+        /// <param name="fillerC"></param>
         /// <param name="fillerConfig"></param>
         public MasQueryParamaters(
             IEnumerable<int> ids , 
@@ -39,9 +40,10 @@ namespace Artesian.SDK.Service
             int? filterId,
             IEnumerable<string> products,
             FillerKindType fillerK,
+            bool fillerC,
             FillerConfig fillerConfig
             )
-            : base(ids, extractionRangeSelectionConfig, extractionRangeType, timezone, filterId, fillerK, fillerConfig)
+            : base(ids, extractionRangeSelectionConfig, extractionRangeType, timezone, filterId, fillerK, fillerC, fillerConfig)
         {
             this.Products = products;
             this.FillerConfig = fillerConfig;

--- a/Artesian/Artesian.SDK/Service/Query/QueryParamaters/QueryWithFillAndIntervalParamaters .cs
+++ b/Artesian/Artesian.SDK/Service/Query/QueryParamaters/QueryWithFillAndIntervalParamaters .cs
@@ -26,6 +26,7 @@ namespace Artesian.SDK.Service
         /// <param name="timezone"></param>
         /// <param name="filterId"></param>
         /// <param name="fillerKind"></param>
+        /// <param name="fillerContinue"></param>
         /// <param name="fillerConfig"></param>
         public QueryWithFillAndIntervalParamaters (
             IEnumerable<int> ids, 
@@ -36,10 +37,12 @@ namespace Artesian.SDK.Service
             string timezone, 
             int? filterId,
             FillerKindType fillerKind,
+            bool fillerContinue,
             FillerConfig fillerConfig
             ): base(ids, extractionRangeSelectionConfig, extractionRangeType, timezone, filterId)
         {
             this.FillerKindType = fillerKind;
+            this.FillerContinue = fillerContinue;
             this.FillerConfig = fillerConfig;
         }
 
@@ -47,6 +50,10 @@ namespace Artesian.SDK.Service
         /// Filler Kind
         /// </summary>
         public FillerKindType FillerKindType { get; set; } = FillerKindType.Default;
+        /// <summary>
+        /// Filler Continue if no end value
+        /// </summary>
+        public bool FillerContinue { get; set; }
         /// <summary>
         /// Filler config
         /// </summary>

--- a/Artesian/Artesian.SDK/Service/Query/QueryParamaters/VersionedQueryParamaters.cs
+++ b/Artesian/Artesian.SDK/Service/Query/QueryParamaters/VersionedQueryParamaters.cs
@@ -34,6 +34,7 @@ namespace Artesian.SDK.Service
         /// <param name="filterId"></param>
         /// <param name="versionLimit"></param>
         /// <param name="fillerK"></param>
+        /// <param name="fillerC"></param>
         /// <param name="fillerConfig"></param>
         public VersionedQueryParamaters(
             IEnumerable<int> ids, 
@@ -47,9 +48,10 @@ namespace Artesian.SDK.Service
             VersionSelectionType? versionSelectionType,
             LocalDateTime? versionLimit,
             FillerKindType fillerK,
+            bool fillerC,
             FillerConfig fillerConfig
             )
-            : base(ids, extractionRangeSelectionConfig, extractionRangeType, timezone, filterId, fillerK, fillerConfig)
+            : base(ids, extractionRangeSelectionConfig, extractionRangeType, timezone, filterId, fillerK, fillerC, fillerConfig)
         {
             this.VersionSelectionConfig = versionSelectionConfig;
             this.VersionSelectionType = versionSelectionType;

--- a/Artesian/Artesian.SDK/Service/Query/VersionedQuery.cs
+++ b/Artesian/Artesian.SDK/Service/Query/VersionedQuery.cs
@@ -351,10 +351,12 @@ namespace Artesian.SDK.Service
         /// Set the Filler Strategy to Latest Value
         /// </summary>
         /// <param name="period"></param>
+        /// <param name="fillerContinue"></param>
         /// <returns>VersionedQuery</returns>
-        public VersionedQuery WithFillLatestValue(Period period)
+        public VersionedQuery WithFillLatestValue(Period period, bool fillerContinue = false)
         {
             _queryParamaters.FillerKindType = FillerKindType.LatestValidValue;
+            _queryParamaters.FillerContinue = fillerContinue;
             _queryParamaters.FillerConfig.FillerPeriod = period;
 
             return this;
@@ -490,6 +492,7 @@ namespace Artesian.SDK.Service
                             .SetQueryParam("tr", qp.TransformId)
                             .SetQueryParam("versionLimit", qp.VersionLimit)
                             .SetQueryParam("fillerK",  qp.FillerKindType)
+                            .SetQueryParam("fillerC", qp.FillerContinue)
                             .SetQueryParam("fillerDV", qp.FillerConfig.FillerTimeSeriesDV)
                             .SetQueryParam("fillerP", qp.FillerConfig.FillerPeriod)
                             .ToString())

--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ Latest Value
  .WithLFillLatestValue(Period.FromDays(7))
 ```
 
+Latest Value ignoring if the is a value at the end of the specified period
+
+```csharp
+ .WithLFillLatestValue(Period.FromDays(7), true)
+```
+
 ## MarketData Service
 
 Using the ArtesianServiceConfig `cfg` we create an instance of the MarketDataService which is used to retrieve and edit


### PR DESCRIPTION
Change to Artesian.SDK to allow filling strategy also if there is no "end value". 

If the requested period for the fill strategy doesn't have an end value already in the curve then the last valid value will be used to fill until the end of the period. As requested in requirement 10171.