### PR TITLE
Revert "Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 in /Artesian"

### DIFF
--- a/Artesian/Artesian.SDK.Tests/Artesian.SDK.Tests.csproj
+++ b/Artesian/Artesian.SDK.Tests/Artesian.SDK.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 	<PackageReference Include="NUnit" Version="3.13.3" />
 	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
 	  <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Reverts ARKlab/Artesian.SDK#35

Automated Tests do not run, although the Workflow Task doesn't fails.

